### PR TITLE
Fix error when setting custom size

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,48 +28,125 @@ The function `initializePowerDmsFilePicker` accepts a configuration object. One 
 
 `initializePowerDmsFilePicker` accepts a configuration object as a single parameter. This object has the following structure:
 
+### JavaScript
+
 ```javascript
 {
-  apiKey,         // string,   required
-  onFileSelected, // function, required
-  width,          // number,   optional
-  height          // number,   optional
+  // String, required
+  // The API key given to your organization from PowerDMS.
+  apiKey,
+
+  // Function, required
+  // A callback that is called when a user makes a selection.
+  onSelection,
+
+  // Number, optional
+  // The desired width of the file picker, in pixels.
+  // Restricted from 566 to 1051.
+  width,
+
+  // Number, optional
+  // The desired height of the file picker, in pixels.
+  // Restricted from 350 o 650.
+  height
 }
 ```
 
-If you are familiar with TypeScript, the properties have these types:
+### TypeScript
 
 ```typescript
-{
-  apiKey: string,
-  onFileSelected: (fileRoute: string) => void,
-  width?: number,
-  height?: number
+type FilePickerConfig = {
+  // The API key given to your organization from PowerDMS.
+  apiKey: string;
+
+  // A callback that is called when a user makes a selection.
+  onSelection: (response: SelectionResponse) => void;
+
+  // The desired width of the file picker, in pixels.
+  // Restricted from 566 to 1051.
+  width?: number;
+
+  // The desired height of the file picker, in pixels.
+  // Restricted from 350 o 650.
+  height?: number;
 }
 ```
 
-### `apiKey`
+## Response data
 
-- Required, string
-- This is the API key given to your organization from PowerDMS.
+### JavaScript
 
-### `onFileSelected`
+```javascript
+// Response
+{
+  // Array of file info objects
+  selectedFiles
+}
 
-- Required, function
-- This is a callback that is called when a user selects a file to import.
-- The string parameter is the URL that can be used to acquire the actual file contents.
-- See [link below](#See-also) for more details on the API.
+// File info
+{
+  // Number
+  documentId,
 
-### `width`
+  // String
+  documentName,
 
-- Optional, number
-- The desired width of the file picker, in pixels. This is restricted from 566 to 1051.
+  // Array of parent folder objects
+  breadcrumbs,
 
-### `height`
+  // Number
+  revisionId,
 
-- Optional, number
-- The desired height of the file picker, in pixels. This is restricted from 350 to 650.
+  // String ('draft', 'published', or 'archived')
+  revisionStatus,
 
-## See also
+  // String
+  // This will be the URL of an API endpoint to get the file contents.
+  contentUrl
+}
 
-For more details on how to use the PowerDMS API, see its [documentation](https://api.powerdms.com/openapi/ui/), specifically the endpoint `/documents/{documentId}/revisions/{revisionId}/content` in the _DocumentRevisionFiles_ section.
+// Parent folder
+{
+  // Number
+  id,
+
+  // String
+  name
+}
+```
+
+### TypeScript
+
+```typescript
+type SelectionResponse = {
+  selectedFiles: ResponseFileInfo[];
+}
+
+type ResponseFileInfo = {
+  documentId: number;
+  documentName: string;
+  breadcrumbs: ResponseParentFolder[];
+  revisionId: number;
+  revisionStatus: ObjectStatus;
+
+  // This will be the URL of an API endpoint to get the file contents.
+  contentUrl: string;
+}
+
+enum ObjectStatus {
+  Draft = 'draft',
+  Published = 'published',
+  Archived = 'archived',
+}
+
+type ResponseParentFolder = {
+  id: number;
+  name: string;
+}
+```
+
+## API usage
+
+For more details on how to use the PowerDMS API, see its [documentation](https://api.powerdms.com/openapi/ui/).
+
+The endpoint to get files contents is `/documents/{documentId}/revisions/{revisionId}/content` in the _DocumentRevisionFiles_ section.

--- a/aspnetcore/FilePickerSample/wwwroot/js/site.js
+++ b/aspnetcore/FilePickerSample/wwwroot/js/site.js
@@ -12,11 +12,11 @@ function openFilePicker() {
     };
 
     if (height) {
-        config.height = height + 'px';
+        config.height = Number(height);
     }
 
     if (width) {
-        config.width = width + 'px';
+        config.width = Number(width);
     }
 
     window.initializePowerDmsFilePicker(config);

--- a/aspnetcore/FilePickerSample/wwwroot/js/site.js
+++ b/aspnetcore/FilePickerSample/wwwroot/js/site.js
@@ -8,9 +8,7 @@ function openFilePicker() {
 
     var config = {
         apiKey: 'fake-api-key',
-        onFileSelected: function (fileRoute) {
-            console.log('File selected: ' + fileRoute);
-        },
+        onSelection: displayResponse,
     };
 
     if (height) {
@@ -22,4 +20,10 @@ function openFilePicker() {
     }
 
     window.initializePowerDmsFilePicker(config);
+}
+
+function displayResponse(response) {
+    var json = JSON.stringify(response, null, 2);
+    var message = 'FilePicker says: \n' + json;
+    alert(message);
 }


### PR DESCRIPTION
The file picker will validate the types of the values set for its configuration. When setting custom sizes in this demo app, the validation was failing because the values were strings.